### PR TITLE
155-fix-zero-value-sorting

### DIFF
--- a/sc4mpclient.py
+++ b/sc4mpclient.py
@@ -2138,8 +2138,8 @@ class ServerList(th.Thread):
 	
 
 	def in_order_index(self, server):
-		
-		if self.get_sort_value(server):
+
+		if self.get_sort_value(server) is not None:
 			existing_server_ids = self.ui.tree.get_children()
 			for index in range(len(existing_server_ids)):
 				existing_server_id = existing_server_ids[index]


### PR DESCRIPTION
## Summary
- Fixed the `in_order_index` method using a truthy check that incorrectly treated zero values (0 mayors, 0% claimed, etc.) as "no value"
- Changed `if self.get_sort_value(server):` to `if self.get_sort_value(server) is not None:` to properly handle zero values

Fixes #155

## Test plan
- [ ] Sort server list by "Mayors" column with servers that have 0 mayors
- [ ] Verify servers with 0 mayors are sorted correctly (not pushed to bottom)
- [ ] Test sorting by other columns (Claimed, Download, Ping) with zero values

🤖 Generated with [Claude Code](https://claude.com/claude-code)