### PR TITLE
151-fix-rank-bar-bounds

### DIFF
--- a/sc4mpclient.py
+++ b/sc4mpclient.py
@@ -2161,7 +2161,9 @@ class ServerList(th.Thread):
 
 		RANK_COLUMN_ID = "#5"
 
-		CUTOFF_Y = 260
+		# Use the actual bounding box of the tree view instead of a constant
+		# This fixes rank bars going out of bounds on different display configurations
+		CUTOFF_Y = self.ui.tree.winfo_height()
 
 		OFFSET_X = 18
 		OFFSET_Y = 154


### PR DESCRIPTION
This PR fixes server rank bars going out of bounds on Windows 7 by replacing the hardcoded CUTOFF_Y constant with a dynamic calculation using the actual tree view height.

## Problem
The rank bars sometimes rendered outside the tree view bounds because they used a hardcoded Y limit of 260 pixels. This didn't account for different display configurations, screen resolutions, or UI layouts, especially on Windows 7.

## Solution
Replaced the hardcoded constant with `self.ui.tree.winfo_height()` which dynamically calculates the actual height of the tree view widget.

## Changes
- Updated `sc4mpclient.py` line 2166: Changed `CUTOFF_Y = 260` to `CUTOFF_Y = self.ui.tree.winfo_height()`
- Added explanatory comment

Fixes #151

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>