### PR TITLE
fix: correct occured->occurred typo in error messages

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -42,11 +42,11 @@ class Config:
 						except (configparser.NoSectionError, configparser.NoOptionError):
 							print(f"[WARNING] Option \"{item_name}\" missing from section \"{section_name}\" of the config file at \"{self.PATH}\". Using default value.")
 						except Exception as e:
-							self.show_error("An error occured while reading a config item.", no_ui=True)
+							self.show_error("An error occurred while reading a config item.", no_ui=True)
 				except Exception as e:
-					self.show_error("An error occured while reading a config section.", no_ui=True)
+					self.show_error("An error occurred while reading a config section.", no_ui=True)
 		except Exception as e:
-			self.show_error("An error occured while reading the config.", no_ui=True)
+			self.show_error("An error occurred while reading the config.", no_ui=True)
 
 		# Update config file
 		self.update()

--- a/sc4mpclient.py
+++ b/sc4mpclient.py
@@ -887,7 +887,7 @@ def start_sc4():
 					time.sleep(1)
 				break
 			except Exception as e:
-				show_error("An error occured while checking if SC4 had exited yet.", no_ui=True)
+				show_error("An error occurred while checking if SC4 had exited yet.", no_ui=True)
 				time.sleep(10)
 	
 	# SimCity 4 has closed
@@ -1435,7 +1435,7 @@ class Server:
 			try:
 				self.update_database()
 			except Exception as e:
-				show_error("An error occured while updating the server database.", no_ui = True)
+				show_error("An error occurred while updating the server database.", no_ui = True)
 
 
 	def fetch_stats(self):
@@ -5404,7 +5404,7 @@ class DirectConnectUI(tk.Toplevel):
 			ServerLoaderUI(Server(host, port))
 			self.destroy()
 		except Exception as e:
-			show_error(f"An unexpected error occured while starting the server loader thread.\n\n{e}")
+			show_error(f"An unexpected error occurred while starting the server loader thread.\n\n{e}")
 
 
 class PasswordDialogUI(tk.Toplevel):


### PR DESCRIPTION
Fix user-facing error messages (issue #158):
- sc4mpclient.py: error occurred while checking if SC4 had exited yet
- sc4mpclient.py: error occurred while updating the server database  
- sc4mpclient.py: error occurred while starting the server loader thread
- core/config.py: error occurred while reading config item/section

Fixes: kegsmr/sc4mp-client#158